### PR TITLE
Remove abspath() from local.module_path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ terraform.*
 /exitstatus.*
 /stdout.*
 /stderr.*
+*.swp

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ provider "null" {
 locals {
   command_chomped              = chomp(var.command)
   command_when_destroy_chomped = chomp(var.command_when_destroy)
-  module_path                  = abspath(path.module)
+  module_path                  = path.module
 }
 
 resource "random_uuid" "uuid" {

--- a/main.tf
+++ b/main.tf
@@ -53,19 +53,19 @@ resource "null_resource" "shell" {
 
   provisioner "local-exec" {
     when       = destroy
-    command    = "rm '${self.triggers.absolute_path}/stdout.${self.triggers.random_uuid}'"
+    command    = "rm '${local.absolute_path}/stdout.${self.triggers.random_uuid}'"
     on_failure = continue
   }
 
   provisioner "local-exec" {
     when       = destroy
-    command    = "rm '${self.triggers.absolute_path}/stderr.${self.triggers.random_uuid}'"
+    command    = "rm '${local.absolute_path}/stderr.${self.triggers.random_uuid}'"
     on_failure = continue
   }
 
   provisioner "local-exec" {
     when       = destroy
-    command    = "rm '${self.triggers.absolute_path}/exitstatus.${self.triggers.random_uuid}'"
+    command    = "rm '${local.absolute_path}/exitstatus.${self.triggers.random_uuid}'"
     on_failure = continue
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,6 @@ resource "null_resource" "shell" {
     command_when_destroy_chomped = local.command_when_destroy_chomped
     environment_keys             = join("__TF_SHELL_RESOURCE_MAGIC_STRING", keys(var.environment))
     environment_values           = join("__TF_SHELL_RESOURCE_MAGIC_STRING", values(var.environment))
-    module_path                  = path.module
     working_dir                  = var.working_dir
     random_uuid                  = random_uuid.uuid.result
   }

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,6 @@ provider "null" {
 locals {
   command_chomped              = chomp(var.command)
   command_when_destroy_chomped = chomp(var.command_when_destroy)
-  module_path                  = path.module
   absolute_path                = abspath(path.module)
 }
 
@@ -20,7 +19,7 @@ resource "null_resource" "shell" {
     command_when_destroy_chomped = local.command_when_destroy_chomped
     environment_keys             = join("__TF_SHELL_RESOURCE_MAGIC_STRING", keys(var.environment))
     environment_values           = join("__TF_SHELL_RESOURCE_MAGIC_STRING", values(var.environment))
-    module_path                  = local.module_path
+    module_path                  = path.module
     working_dir                  = var.working_dir
     random_uuid                  = random_uuid.uuid.result
   }
@@ -52,21 +51,24 @@ resource "null_resource" "shell" {
   }
 
   provisioner "local-exec" {
-    when       = destroy
-    command    = "rm '${local.absolute_path}/stdout.${self.triggers.random_uuid}'"
-    on_failure = continue
+    when        = destroy
+    command     = "rm 'stdout.${self.triggers.random_uuid}'"
+    on_failure  = continue
+    working_dir = path.module
   }
 
   provisioner "local-exec" {
-    when       = destroy
-    command    = "rm '${local.absolute_path}/stderr.${self.triggers.random_uuid}'"
-    on_failure = continue
+    when        = destroy
+    command     = "rm 'stderr.${self.triggers.random_uuid}'"
+    on_failure  = continue
+    working_dir = path.module
   }
 
   provisioner "local-exec" {
-    when       = destroy
-    command    = "rm '${local.absolute_path}/exitstatus.${self.triggers.random_uuid}'"
-    on_failure = continue
+    when        = destroy
+    command     = "rm 'exitstatus.${self.triggers.random_uuid}'"
+    on_failure  = continue
+    working_dir = path.module
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,7 @@ locals {
   command_chomped              = chomp(var.command)
   command_when_destroy_chomped = chomp(var.command_when_destroy)
   module_path                  = path.module
+  absolute_path                = abspath(path.module)
 }
 
 resource "random_uuid" "uuid" {
@@ -34,8 +35,8 @@ resource "null_resource" "shell" {
     working_dir = self.triggers.working_dir
 
     interpreter = [
-      "${local.module_path}/run.sh",
-      local.module_path,
+      "${local.absolute_path}/run.sh",
+      local.absolute_path,
       self.triggers.random_uuid
     ]
   }
@@ -52,27 +53,27 @@ resource "null_resource" "shell" {
 
   provisioner "local-exec" {
     when       = destroy
-    command    = "rm '${self.triggers.module_path}/stdout.${self.triggers.random_uuid}'"
+    command    = "rm '${self.triggers.absolute_path}/stdout.${self.triggers.random_uuid}'"
     on_failure = continue
   }
 
   provisioner "local-exec" {
     when       = destroy
-    command    = "rm '${self.triggers.module_path}/stderr.${self.triggers.random_uuid}'"
+    command    = "rm '${self.triggers.absolute_path}/stderr.${self.triggers.random_uuid}'"
     on_failure = continue
   }
 
   provisioner "local-exec" {
     when       = destroy
-    command    = "rm '${self.triggers.module_path}/exitstatus.${self.triggers.random_uuid}'"
+    command    = "rm '${self.triggers.absolute_path}/exitstatus.${self.triggers.random_uuid}'"
     on_failure = continue
   }
 }
 
 locals {
-  stdout     = "${local.module_path}/stdout.${random_uuid.uuid.result}"
-  stderr     = "${local.module_path}/stderr.${random_uuid.uuid.result}"
-  exitstatus = "${local.module_path}/exitstatus.${random_uuid.uuid.result}"
+  stdout     = "${local.absolute_path}/stdout.${random_uuid.uuid.result}"
+  stderr     = "${local.absolute_path}/stderr.${random_uuid.uuid.result}"
+  exitstatus = "${local.absolute_path}/exitstatus.${random_uuid.uuid.result}"
 }
 
 resource "null_resource" "contents" {


### PR DESCRIPTION
See https://github.com/matti/terraform-shell-resource/issues/22

@matti 

## Changes

* dropped the `module_path` trigger which contained the `absolute_path` which contained the user who ran the command
* removed `null_resource.triggers.module_path` by adding `working_dir` set to `path.module` in order to remove the deprecation warning in recent versions of terraform which is currently being discussed [here](https://github.com/hashicorp/terraform/issues/23679).
* `terraform fmt`