### PR TITLE
Windows Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ Outputs:
 greeting = hello world from /private/tmp where /tmp/first has content: I was here first
 ```
 
+## Windows support
+This module also supports being run on Windows machines (assuming they support Powershell). If the `command_windows` and/or `command_when_destroy_windows` inputs are specified, they will be used instead of `command`/`command_when_destroy` when Terraform is run on Windows. If they are not specified, the `command`/`command_when_destroy` commands will be run regardless of the operating system.
+
 ## Additional examples
 
 See [tests](tests) and [examples](examples)

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,9 @@
 locals {
   is_windows                   = dirname("/") == "\\"
-  command_chomped              = chomp(local.is_windows ? var.command_windows : var.command)
-  command_when_destroy_chomped = chomp(local.is_windows ? var.command_when_destroy_windows : var.command_when_destroy)
+  command_windows = var.command_windows != "" ? var.command_windows : var.command
+  command_when_destroy_windows = var.command_when_destroy_windows != "" ? var.command_when_destroy_windows : var.command_when_destroy
+  command_chomped              = chomp(local.is_windows ? local.command_windows : var.command)
+  command_when_destroy_chomped = chomp(local.is_windows ? local.command_when_destroy_windows : var.command_when_destroy)
   temporary_dir                = abspath(path.module)
   interpreter                  = local.is_windows ? ["powershell.exe", "${abspath(path.module)}/run.ps1"] : ["${abspath(path.module)}/run.sh"]
 }

--- a/run.ps1
+++ b/run.ps1
@@ -1,0 +1,25 @@
+
+# Equivalent of set -e
+$ErrorActionPreference = "Stop"
+
+# Equivalent of set -u (https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/set-strictmode?view=powershell-7.1)
+set-strictmode -version 3.0
+$_path = $args[0]
+$_id = $args[1]
+$_cmd = $args[2..($args.length - 1)]
+
+# Equivalent of set +e
+$ErrorActionPreference = "Continue"
+$exitcode = 0
+try {
+    powershell.exe @_cmd 2>"$_path/stderr.$_id" >"$_path/stdout.$_id"
+    if ($LASTEXITCODE) { 
+        $exitcode = $LASTEXITCODE
+        #throw $er 
+    }
+}
+catch {
+    #$exitcode = $_
+}
+[System.IO.File]::WriteAllText("$_path/exitstatus.$_id", "$exitcode", [System.Text.Encoding]::ASCII)
+$ErrorActionPreference = "Stop"

--- a/run.ps1
+++ b/run.ps1
@@ -10,16 +10,7 @@ $_cmd = $args[2..($args.length - 1)]
 
 # Equivalent of set +e
 $ErrorActionPreference = "Continue"
-$exitcode = 0
-try {
-    powershell.exe @_cmd 2>"$_path/stderr.$_id" >"$_path/stdout.$_id"
-    if ($LASTEXITCODE) { 
-        $exitcode = $LASTEXITCODE
-        #throw $er 
-    }
-}
-catch {
-    #$exitcode = $_
-}
+$process = Start-Process powershell.exe -ArgumentList "$($_cmd -join " ")" -Wait -PassThru -NoNewWindow -RedirectStandardError "$_path/stderr.$_id" -RedirectStandardOutput "$_path/stdout.$_id"
+$exitcode = $process.ExitCode
 [System.IO.File]::WriteAllText("$_path/exitstatus.$_id", "$exitcode", [System.Text.Encoding]::ASCII)
 $ErrorActionPreference = "Stop"

--- a/run.ps1
+++ b/run.ps1
@@ -10,7 +10,7 @@ $_cmd = $args[2..($args.length - 1)]
 
 # Equivalent of set +e
 $ErrorActionPreference = "Continue"
-$process = Start-Process powershell.exe -ArgumentList "$($_cmd -join " ")" -Wait -PassThru -NoNewWindow -RedirectStandardError "$_path/stderr.$_id" -RedirectStandardOutput "$_path/stdout.$_id"
+$process = Start-Process powershell.exe -ArgumentList "$_cmd" -Wait -PassThru -NoNewWindow -RedirectStandardError "$_path/stderr.$_id" -RedirectStandardOutput "$_path/stdout.$_id"
 $exitcode = $process.ExitCode
 [System.IO.File]::WriteAllText("$_path/exitstatus.$_id", "$exitcode", [System.Text.Encoding]::ASCII)
 $ErrorActionPreference = "Stop"

--- a/variables.tf
+++ b/variables.tf
@@ -1,23 +1,29 @@
 variable "depends" {
+  description = "Equivalent to the `depends_on` input for a data/resource."
   default = []
 }
 
 variable "command" {
+  description = "The command to run on creation when the module is used on a Unix machine."
   default = ":"
 }
 variable "command_windows" {
-  default = ":"
+  description = "(Optional) The command to run on creation when the module is used on a Windows machine. If not specified, will default to be the same as the `command` variable."
+  default = ""
 }
 
 variable "command_when_destroy" {
+  description = "The command to run on destruction when the module is used on a Unix machine."
   default = ":"
 }
 variable "command_when_destroy_windows" {
-  default = ":"
+  description = "(Optional) The command to run on destruction when the module is used on a Windows machine. If not specified, will default to be the same as the `command_when_destroy` variable."
+  default = ""
 }
 
 # warning! the outputs are not updated even if the trigger re-runs the command!
 variable "trigger" {
+  description = "When any of these values change, re-run the script (will first run the destroy command if this module already exists in the state)."
   default = ""
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -5,8 +5,14 @@ variable "depends" {
 variable "command" {
   default = ":"
 }
+variable "command_windows" {
+  default = ":"
+}
 
 variable "command_when_destroy" {
+  default = ":"
+}
+variable "command_when_destroy_windows" {
   default = ":"
 }
 


### PR DESCRIPTION
This PR implements Windows (PowerShell) support. If `terraform apply` is run on a Windows machine, it will use PowerShell to run the new `command_windows` and `command_when_destroy_windows` input commands (if they are not specified, it will try to run the `command`/`command_when_destroy` commands).

It seems to be working but could use some more testing. Unfortunately, the Bats tests don't work on Windows so if automated testing is desired another framework would need to be used.

I've also updated some of the input variable documentation (some inputs were missing descriptions).