### PR TITLE
Fix for default Windows commands

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,13 @@
 locals {
   is_windows                   = dirname("/") == "\\"
-  command_windows = var.command_windows != "" ? var.command_windows : var.command
-  command_when_destroy_windows = var.command_when_destroy_windows != "" ? var.command_when_destroy_windows : var.command_when_destroy
-  command_chomped              = chomp(local.is_windows ? local.command_windows : var.command)
-  command_when_destroy_chomped = chomp(local.is_windows ? local.command_when_destroy_windows : var.command_when_destroy)
+  // The command that does nothing (differs depending on platform)
+  null_command = local.is_windows ? "% ':'" : ":"
+  command = var.command != null ? var.command : local.null_command
+  command_windows = var.command_windows != null ? var.command_windows : local.command
+  command_when_destroy = var.command_when_destroy != null ? var.command_when_destroy : local.null_command
+  command_when_destroy_windows = var.command_when_destroy_windows != null ? var.command_when_destroy_windows : local.command_when_destroy
+  command_chomped              = chomp(local.is_windows ? local.command_windows : local.command)
+  command_when_destroy_chomped = chomp(local.is_windows ? local.command_when_destroy_windows : local.command_when_destroy)
   temporary_dir                = abspath(path.module)
   interpreter                  = local.is_windows ? ["powershell.exe", "${abspath(path.module)}/run.ps1"] : ["${abspath(path.module)}/run.sh"]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -5,25 +5,25 @@ variable "depends" {
 
 variable "command" {
   description = "The command to run on creation when the module is used on a Unix machine."
-  default = ":"
+  default = null
 }
 variable "command_windows" {
   description = "(Optional) The command to run on creation when the module is used on a Windows machine. If not specified, will default to be the same as the `command` variable."
-  default = ""
+  default = null
 }
 
 variable "command_when_destroy" {
   description = "The command to run on destruction when the module is used on a Unix machine."
-  default = ":"
+  default = null
 }
 variable "command_when_destroy_windows" {
   description = "(Optional) The command to run on destruction when the module is used on a Windows machine. If not specified, will default to be the same as the `command_when_destroy` variable."
-  default = ""
+  default = null
 }
 
 # warning! the outputs are not updated even if the trigger re-runs the command!
 variable "trigger" {
-  description = "When any of these values change, re-run the script (will first run the destroy command if this module already exists in the state)."
+  description = "A string value that, when changed, will cause the script to be re-run (will first run the destroy command if this module already exists in the state)."
   default = ""
 }
 


### PR DESCRIPTION
This is a patch for PR #36 . Further testing discovered there was an issue with default commands (`:` is not a valid command in Powershell).