### PR TITLE
Triggerless Environment Variables

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,10 @@
 locals {
-  is_windows                   = dirname("/") == "\\"
+  is_windows = dirname("/") == "\\"
   // The command that does nothing (differs depending on platform)
-  null_command = local.is_windows ? "% ':'" : ":"
-  command = var.command != null ? var.command : local.null_command
-  command_windows = var.command_windows != null ? var.command_windows : local.command
-  command_when_destroy = var.command_when_destroy != null ? var.command_when_destroy : local.null_command
+  null_command                 = local.is_windows ? "% ':'" : ":"
+  command                      = var.command != null ? var.command : local.null_command
+  command_windows              = var.command_windows != null ? var.command_windows : local.command
+  command_when_destroy         = var.command_when_destroy != null ? var.command_when_destroy : local.null_command
   command_when_destroy_windows = var.command_when_destroy_windows != null ? var.command_when_destroy_windows : local.command_when_destroy
   command_chomped              = chomp(local.is_windows ? local.command_windows : local.command)
   command_when_destroy_chomped = chomp(local.is_windows ? local.command_when_destroy_windows : local.command_when_destroy)
@@ -35,7 +35,7 @@ resource "null_resource" "shell" {
     environment = merge(zipmap(
       split("__TF_SHELL_RESOURCE_MAGIC_STRING", self.triggers.environment_keys),
       split("__TF_SHELL_RESOURCE_MAGIC_STRING", self.triggers.environment_values)
-    ), var.sensitive_environment)
+    ), var.triggerless_environment, var.sensitive_environment)
     working_dir = self.triggers.working_dir
 
     interpreter = concat(local.interpreter, [

--- a/main.tf
+++ b/main.tf
@@ -35,7 +35,7 @@ resource "null_resource" "shell" {
     environment = merge(zipmap(
       split("__TF_SHELL_RESOURCE_MAGIC_STRING", self.triggers.environment_keys),
       split("__TF_SHELL_RESOURCE_MAGIC_STRING", self.triggers.environment_values)
-    ), var.triggerless_environment, var.sensitive_environment)
+    ), var.sensitive_environment, var.triggerless_environment)
     working_dir = self.triggers.working_dir
 
     interpreter = concat(local.interpreter, [

--- a/variables.tf
+++ b/variables.tf
@@ -1,30 +1,30 @@
 variable "depends" {
   description = "Equivalent to the `depends_on` input for a data/resource."
-  default = []
+  default     = []
 }
 
 variable "command" {
   description = "The command to run on creation when the module is used on a Unix machine."
-  default = null
+  default     = null
 }
 variable "command_windows" {
   description = "(Optional) The command to run on creation when the module is used on a Windows machine. If not specified, will default to be the same as the `command` variable."
-  default = null
+  default     = null
 }
 
 variable "command_when_destroy" {
   description = "The command to run on destruction when the module is used on a Unix machine."
-  default = null
+  default     = null
 }
 variable "command_when_destroy_windows" {
   description = "(Optional) The command to run on destruction when the module is used on a Windows machine. If not specified, will default to be the same as the `command_when_destroy` variable."
-  default = null
+  default     = null
 }
 
 # warning! the outputs are not updated even if the trigger re-runs the command!
 variable "trigger" {
   description = "A string value that, when changed, will cause the script to be re-run (will first run the destroy command if this module already exists in the state)."
-  default = ""
+  default     = ""
 }
 
 variable "environment" {
@@ -43,4 +43,10 @@ variable "working_dir" {
   type        = string
   default     = ""
   description = "(Optional) the working directory where command will be executed"
+}
+
+variable "triggerless_environment" {
+  type        = map(string)
+  default     = {}
+  description = "(Optional) Map of environment variables to pass to the command, which will NOT trigger a resource re-create if changed."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -30,23 +30,23 @@ variable "trigger" {
 variable "environment" {
   type        = map(string)
   default     = {}
-  description = "(Optional) Map of environment variables to pass to the command"
+  description = "(Optional) Map of environment variables to pass to the command. Will be merged with `sensitive_environment` and `triggerless_environment`."
 }
 
 variable "sensitive_environment" {
   type        = map(string)
   default     = {}
-  description = "(Optional) Map of (sentitive) environment variables to pass to the command"
-}
-
-variable "working_dir" {
-  type        = string
-  default     = ""
-  description = "(Optional) the working directory where command will be executed"
+  description = "(Optional) Map of (sentitive) environment variables to pass to the command. Will be merged with `environment` and `triggerless_environment`."
 }
 
 variable "triggerless_environment" {
   type        = map(string)
   default     = {}
-  description = "(Optional) Map of environment variables to pass to the command, which will NOT trigger a resource re-create if changed."
+  description = "(Optional) Map of environment variables to pass to the command, which will NOT trigger a resource re-create if changed. Will be merged with `environment` and `sensitive_environment`."
+}
+
+variable "working_dir" {
+  type        = string
+  default     = ""
+  description = "(Optional) the working directory where command will be executed."
 }


### PR DESCRIPTION
This PR adds an additional input variable for `triggerless_environment`, which is a set of environment variables that **do not** trigger a resource re-create if they're changed.

I ran into this issue where I was setting temporary STS token values in the environment variables, but since STS tokens change regularly, it wanted to re-create the resource each time. By setting these env vars in the new `triggerless_environment` input, they still get sent through to the script but don't trigger a re-create each time.