### PR TITLE
Powershell fix + option to fail on error

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,9 +32,10 @@ resource "null_resource" "shell" {
   provisioner "local-exec" {
     command = local.command_chomped
 
+    // Due to the join/split of environment keys/vars, we need to check for empty strings to prevent an env var of ""="", which Powershell does not like
     environment = merge(zipmap(
-      split("__TF_SHELL_RESOURCE_MAGIC_STRING", self.triggers.environment_keys),
-      split("__TF_SHELL_RESOURCE_MAGIC_STRING", self.triggers.environment_values)
+      self.triggers.environment_keys == "" ? [] : split("__TF_SHELL_RESOURCE_MAGIC_STRING", self.triggers.environment_keys),
+      self.triggers.environment_values == "" ? [] : split("__TF_SHELL_RESOURCE_MAGIC_STRING", self.triggers.environment_values)
     ), var.sensitive_environment, var.triggerless_environment)
     working_dir = self.triggers.working_dir
 

--- a/run.ps1
+++ b/run.ps1
@@ -6,11 +6,24 @@ $ErrorActionPreference = "Stop"
 set-strictmode -version 3.0
 $_path = $args[0]
 $_id = $args[1]
-$_cmd = $args[2..($args.length - 1)]
+$_failonerr = $args[2]
+$_cmd = $args[3..($args.length - 1)]
+
+$_stderrfile = "$_path/stderr.$_id"
+$_stdoutfile = "$_path/stdout.$_id"
+$_exitcodefile = "$_path/exitstatus.$_id"
 
 # Equivalent of set +e
 $ErrorActionPreference = "Continue"
-$process = Start-Process powershell.exe -ArgumentList "$_cmd" -Wait -PassThru -NoNewWindow -RedirectStandardError "$_path/stderr.$_id" -RedirectStandardOutput "$_path/stdout.$_id"
-$exitcode = $process.ExitCode
-[System.IO.File]::WriteAllText("$_path/exitstatus.$_id", "$exitcode", [System.Text.Encoding]::ASCII)
+$_process = Start-Process powershell.exe -ArgumentList "$_cmd" -Wait -PassThru -NoNewWindow -RedirectStandardError "$_stderrfile" -RedirectStandardOutput "$_stdoutfile"
+$_exitcode = $_process.ExitCode
 $ErrorActionPreference = "Stop"
+
+[System.IO.File]::WriteAllText("$_exitcodefile", "$_exitcode", [System.Text.Encoding]::ASCII)
+
+if (( "$_failonerr" -eq "true" ) -and $_exitcode) {
+    # If it should fail on an error, and it did fail, read the stderr file
+    # Exit with the error message and code
+    Write-Error [IO.File]::ReadAllText("$_stderrfile")
+    exit $_exitcode
+}

--- a/run.sh
+++ b/run.sh
@@ -3,8 +3,23 @@ set -eu
 
 _path=$1; shift
 _id=$1; shift
+_failonerr=$1; shift
+
+_stderrfile="$_path/stderr.$_id"
+_stdoutfile="$_path/stdout.$_id"
+_exitcodefile="$_path/exitstatus.$_id"
 
 set +e
-  2>"$_path/stderr.$_id" >"$_path/stdout.$_id" sh -c "$@"
-  >"$_path/exitstatus.$_id" echo $?
+  2>"$_stderrfile" >"$_stdoutfile" sh -c "$@"
+  _exitcode=$?
 set -e
+
+>"$_exitcodefile" echo $_exitcode
+
+if [ "$_failonerr" = "true" ] && ! [ -z $_exitcode ]; then
+  # If it should fail on an error, and it did fail, read the stderr file
+  _stderr=$(cat "$_stderrfile")
+  # Exit with the error message and code
+  >&2 echo "$_stderr"
+  exit $_exitcode
+fi

--- a/variables.tf
+++ b/variables.tf
@@ -1,10 +1,10 @@
 variable "depends" {
-  description = "Equivalent to the `depends_on` input for a data/resource."
+  description = "(Optional) Equivalent to the `depends_on` input for a data/resource."
   default     = []
 }
 
 variable "command" {
-  description = "The command to run on creation when the module is used on a Unix machine."
+  description = "(Optional) The command to run on creation when the module is used on a Unix machine."
   default     = null
 }
 variable "command_windows" {
@@ -13,9 +13,10 @@ variable "command_windows" {
 }
 
 variable "command_when_destroy" {
-  description = "The command to run on destruction when the module is used on a Unix machine."
+  description = "(Optional) The command to run on destruction when the module is used on a Unix machine."
   default     = null
 }
+
 variable "command_when_destroy_windows" {
   description = "(Optional) The command to run on destruction when the module is used on a Windows machine. If not specified, will default to be the same as the `command_when_destroy` variable."
   default     = null
@@ -23,7 +24,7 @@ variable "command_when_destroy_windows" {
 
 # warning! the outputs are not updated even if the trigger re-runs the command!
 variable "trigger" {
-  description = "A string value that, when changed, will cause the script to be re-run (will first run the destroy command if this module already exists in the state)."
+  description = "(Optional) A string value that, when changed, will cause the script to be re-run (will first run the destroy command if this module already exists in the state)."
   default     = ""
 }
 
@@ -48,5 +49,11 @@ variable "triggerless_environment" {
 variable "working_dir" {
   type        = string
   default     = ""
-  description = "(Optional) the working directory where command will be executed."
+  description = "(Optional) The working directory where command will be executed."
+}
+
+variable "fail_on_error" {
+  type        = bool
+  default     = false
+  description = "(Optional) Whether a Terraform error should be thrown if the command throws an error. If true, nothing will be returned from this module and Terraform will fail the apply. If false, the error message will be returned in `stderr` and the error code will be returned in `exitcode`. Default: `false`."
 }


### PR DESCRIPTION
A user messaged me with a bug when running on Windows (#39). Turns out that the existing join/split with the magic string for environment variables will result in an environment map of:
```
{
    "" = ""
}
```
If no environment variables are specified. It seems that Linux shell is OK with this, but Powershell is not. This PR adds a check for that condition to provide an actually empty env var map if none are specified.

This PR also adds a `fail_on_error` bool input variable, which does what it says on the label. If the command returns a non-zero error code, it causes the Terraform apply to fail (instead of succeeding and returning `stderr`/`exitcode` in the module output). This new variable defaults to `false`. This addresses #34.

Note that while these changes are backwards-compatible (all existing input/output variables are the same), updating the module to this new code will trigger the resource to be re-created the first time it's run, regardless of whether the input variables have changed.