### PR TITLE
Add map `triggers`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ resource "random_uuid" "uuid" {
 }
 
 resource "null_resource" "shell" {
-  triggers = {
+  triggers = merge({
     trigger                      = var.trigger
     command_unix                 = local.command_unix
     command_windows              = local.command_windows
@@ -26,7 +26,7 @@ resource "null_resource" "shell" {
     working_dir                  = var.working_dir
     random_uuid                  = random_uuid.uuid.result
     fail_on_error                = var.fail_on_error
-  }
+  }, var.triggers)
 
   provisioner "local-exec" {
     command = local.is_windows ? self.triggers.command_windows : self.triggers.command_unix

--- a/variables.tf
+++ b/variables.tf
@@ -28,6 +28,12 @@ variable "trigger" {
   default     = ""
 }
 
+variable "triggers" {
+  type        = any
+  default     = {}
+  description = "(Optional) A map value that, when changed, will cause the script to be re-run (will first run the destroy command if this module already exists in the state)."
+}
+
 variable "environment" {
   type        = map(string)
   default     = {}


### PR DESCRIPTION
It would be nice to add an arbitrary list of `triggers` like we can with the `null_resource`.

This is a backwards compatible change which simply uses `merge()` to add more to the existing `null_resource` triggers.